### PR TITLE
Why is there a click event after simulate drag?

### DIFF
--- a/jquery.simulate.js
+++ b/jquery.simulate.js
@@ -305,7 +305,6 @@ $.extend( $.simulate.prototype, {
 		}
 
 		this.simulateEvent( target, "mouseup", coord );
-		this.simulateEvent( target, "click", coord );
 	}
 });
 


### PR DESCRIPTION
Hello Everyone,

i just want to pull this to make a point. Why is there an aditional click event triggered?
Normally dragigng is just:
mousedown - moveit - mouseup
isn't it?

Is some strange browser doing this?

best regards
Philipp
