### PR TITLE
drag event without move and zero deltas

### DIFF
--- a/AUTHORS.TXT
+++ b/AUTHORS.TXT
@@ -7,3 +7,4 @@ Trey Hunner <treyhunner@gmail.com>
 Mike Sherov <mike.sherov@gmail.com>
 Andrei Picus <office.nightcrawler@gmail.com>
 Lars Laade <lars.laade@googlemail.com>
+Maicol Petozzi <maicolpt@gmail.com>

--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-	"name": "jquery-simulate",
+	"name": "jquerySimulate",
 	"devDependencies": {
 		"qunit": "1.14.0",
 		"jquery-1.6.0": "jquery#1.6.0",

--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,6 @@
 {
 	"name": "jquerySimulate",
+	"main": "./jquery.simulate.js",
 	"devDependencies": {
 		"qunit": "1.14.0",
 		"jquery-1.6.0": "jquery#1.6.0",

--- a/jquery.simulate.js
+++ b/jquery.simulate.js
@@ -291,6 +291,10 @@ function findCorner( elem ) {
 	};
 }
 
+function hasNoMoves(moves, dx, dy) {
+	return typeof(moves) !== "number" || (moves === 0 && (dx !== 0 || dy !== 0));
+}
+
 $.extend( $.simulate.prototype, {
 	simulateDrag: function() {
 		var i = 0,
@@ -302,7 +306,7 @@ $.extend( $.simulate.prototype, {
 			coord = { clientX: x, clientY: y },
 			dx = options.dx || ( options.x !== undefined ? options.x - x : 0 ),
 			dy = options.dy || ( options.y !== undefined ? options.y - y : 0 ),
-			moves = options.moves || 3;
+			moves = hasNoMoves(options.moves, dx, dy) ? 3 : options.moves;
 
 		this.simulateEvent( target, "mousedown", coord );
 

--- a/jquery.simulate.js
+++ b/jquery.simulate.js
@@ -1,4 +1,4 @@
- /*!
+/*!
  * jQuery Simulate v@VERSION - simulate browser mouse and keyboard events
  * https://github.com/jquery/jquery-simulate
  *
@@ -9,302 +9,304 @@
  * Date: @DATE
  */
 
-;(function( $, undefined ) {
+;
+(function ($, undefined) {
 
-var rkeyEvent = /^key/,
-	rmouseEvent = /^(?:mouse|contextmenu)|click/;
+    var rkeyEvent = /^key/,
+        rmouseEvent = /^(?:mouse|contextmenu)|click/;
 
-$.fn.simulate = function( type, options ) {
-	return this.each(function() {
-		new $.simulate( this, type, options );
-	});
-};
+    $.fn.simulate = function (type, options) {
+        return this.each(function () {
+            new $.simulate(this, type, options);
+        });
+    };
 
-$.simulate = function( elem, type, options ) {
-	var method = $.camelCase( "simulate-" + type );
+    $.simulate = function (elem, type, options) {
+        var method = $.camelCase("simulate-" + type);
 
-	this.target = elem;
-	this.options = options;
+        this.target = elem;
+        this.options = options;
 
-	if ( this[ method ] ) {
-		this[ method ]();
-	} else {
-		this.simulateEvent( elem, type, options );
-	}
-};
+        if (this[method]) {
+            this[method]();
+        } else {
+            this.simulateEvent(elem, type, options);
+        }
+    };
 
-$.extend( $.simulate, {
+    $.extend($.simulate, {
 
-	keyCode: {
-		BACKSPACE: 8,
-		COMMA: 188,
-		DELETE: 46,
-		DOWN: 40,
-		END: 35,
-		ENTER: 13,
-		ESCAPE: 27,
-		HOME: 36,
-		LEFT: 37,
-		NUMPAD_ADD: 107,
-		NUMPAD_DECIMAL: 110,
-		NUMPAD_DIVIDE: 111,
-		NUMPAD_ENTER: 108,
-		NUMPAD_MULTIPLY: 106,
-		NUMPAD_SUBTRACT: 109,
-		PAGE_DOWN: 34,
-		PAGE_UP: 33,
-		PERIOD: 190,
-		RIGHT: 39,
-		SPACE: 32,
-		TAB: 9,
-		UP: 38
-	},
+        keyCode: {
+            BACKSPACE: 8,
+            COMMA: 188,
+            DELETE: 46,
+            DOWN: 40,
+            END: 35,
+            ENTER: 13,
+            ESCAPE: 27,
+            HOME: 36,
+            LEFT: 37,
+            NUMPAD_ADD: 107,
+            NUMPAD_DECIMAL: 110,
+            NUMPAD_DIVIDE: 111,
+            NUMPAD_ENTER: 108,
+            NUMPAD_MULTIPLY: 106,
+            NUMPAD_SUBTRACT: 109,
+            PAGE_DOWN: 34,
+            PAGE_UP: 33,
+            PERIOD: 190,
+            RIGHT: 39,
+            SPACE: 32,
+            TAB: 9,
+            UP: 38
+        },
 
-	buttonCode: {
-		LEFT: 0,
-		MIDDLE: 1,
-		RIGHT: 2
-	}
-});
+        buttonCode: {
+            LEFT: 0,
+            MIDDLE: 1,
+            RIGHT: 2
+        }
+    });
 
-$.extend( $.simulate.prototype, {
+    $.extend($.simulate.prototype, {
 
-	simulateEvent: function( elem, type, options ) {
-		var event = this.createEvent( type, options );
-		this.dispatchEvent( elem, type, event, options );
-	},
+        simulateEvent: function (elem, type, options) {
+            var event = this.createEvent(type, options);
+            this.dispatchEvent(elem, type, event, options);
+        },
 
-	createEvent: function( type, options ) {
-		if ( rkeyEvent.test( type ) ) {
-			return this.keyEvent( type, options );
-		}
+        createEvent: function (type, options) {
+            if (rkeyEvent.test(type)) {
+                return this.keyEvent(type, options);
+            }
 
-		if ( rmouseEvent.test( type ) ) {
-			return this.mouseEvent( type, options );
-		}
-	},
+            if (rmouseEvent.test(type)) {
+                return this.mouseEvent(type, options);
+            }
+        },
 
-	mouseEvent: function( type, options ) {
-		var event, eventDoc, doc, body;
-		options = $.extend({
-			bubbles: true,
-			cancelable: (type !== "mousemove"),
-			view: window,
-			detail: 0,
-			screenX: 0,
-			screenY: 0,
-			clientX: 1,
-			clientY: 1,
-			ctrlKey: false,
-			altKey: false,
-			shiftKey: false,
-			metaKey: false,
-			button: 0,
-			relatedTarget: undefined
-		}, options );
+        mouseEvent: function (type, options) {
+            var event, eventDoc, doc, body;
+            options = $.extend({
+                bubbles: true,
+                cancelable: (type !== "mousemove"),
+                view: window,
+                detail: 0,
+                screenX: 0,
+                screenY: 0,
+                clientX: 1,
+                clientY: 1,
+                ctrlKey: false,
+                altKey: false,
+                shiftKey: false,
+                metaKey: false,
+                button: 0,
+                relatedTarget: undefined
+            }, options);
 
-		if ( document.createEvent ) {
-			event = document.createEvent( "MouseEvents" );
-			event.initMouseEvent( type, options.bubbles, options.cancelable,
-				options.view, options.detail,
-				options.screenX, options.screenY, options.clientX, options.clientY,
-				options.ctrlKey, options.altKey, options.shiftKey, options.metaKey,
-				options.button, options.relatedTarget || document.body.parentNode );
-		} else if ( document.createEventObject ) {
-			event = document.createEventObject();
-			$.extend( event, options );
-			// standards event.button uses constants defined here: http://msdn.microsoft.com/en-us/library/ie/ff974877(v=vs.85).aspx
-			// old IE event.button uses constants defined here: http://msdn.microsoft.com/en-us/library/ie/ms533544(v=vs.85).aspx
-			// so we actually need to map the standard back to oldIE
-			event.button = {
-				0: 1,
-				1: 4,
-				2: 2
-			}[ event.button ] || ( event.button === -1 ? 0 : event.button );
-		}
+            if (document.createEvent) {
+                event = document.createEvent("MouseEvents");
+                event.initMouseEvent(type, options.bubbles, options.cancelable,
+                    options.view, options.detail,
+                    options.screenX, options.screenY, options.clientX, options.clientY,
+                    options.ctrlKey, options.altKey, options.shiftKey, options.metaKey,
+                    options.button, options.relatedTarget || document.body.parentNode);
+            } else if (document.createEventObject) {
+                event = document.createEventObject();
+                $.extend(event, options);
+                // standards event.button uses constants defined here: http://msdn.microsoft.com/en-us/library/ie/ff974877(v=vs.85).aspx
+                // old IE event.button uses constants defined here: http://msdn.microsoft.com/en-us/library/ie/ms533544(v=vs.85).aspx
+                // so we actually need to map the standard back to oldIE
+                event.button = {
+                    0: 1,
+                    1: 4,
+                    2: 2
+                }[event.button] || (event.button === -1 ? 0 : event.button);
+            }
 
-		return event;
-	},
+            return event;
+        },
 
-	keyEvent: function( type, options ) {
-		var event;
-		options = $.extend({
-			bubbles: true,
-			cancelable: true,
-			view: window,
-			ctrlKey: false,
-			altKey: false,
-			shiftKey: false,
-			metaKey: false,
-			keyCode: 0,
-			charCode: undefined
-		}, options );
+        keyEvent: function (type, options) {
+            var event;
+            options = $.extend({
+                bubbles: true,
+                cancelable: true,
+                view: window,
+                ctrlKey: false,
+                altKey: false,
+                shiftKey: false,
+                metaKey: false,
+                keyCode: 0,
+                charCode: undefined
+            }, options);
 
-		if ( document.createEvent ) {
-			try {
-				event = document.createEvent( "KeyEvents" );
-				event.initKeyEvent( type, options.bubbles, options.cancelable, options.view,
-					options.ctrlKey, options.altKey, options.shiftKey, options.metaKey,
-					options.keyCode, options.charCode );
-			// initKeyEvent throws an exception in WebKit
-			// see: http://stackoverflow.com/questions/6406784/initkeyevent-keypress-only-works-in-firefox-need-a-cross-browser-solution
-			// and also https://bugs.webkit.org/show_bug.cgi?id=13368
-			// fall back to a generic event until we decide to implement initKeyboardEvent
-			} catch( err ) {
-				event = document.createEvent( "Events" );
-				event.initEvent( type, options.bubbles, options.cancelable );
-				$.extend( event, {
-					view: options.view,
-					ctrlKey: options.ctrlKey,
-					altKey: options.altKey,
-					shiftKey: options.shiftKey,
-					metaKey: options.metaKey,
-					keyCode: options.keyCode,
-					charCode: options.charCode
-				});
-			}
-		} else if ( document.createEventObject ) {
-			event = document.createEventObject();
-			$.extend( event, options );
-		}
+            if (document.createEvent) {
+                try {
+                    event = document.createEvent("KeyEvents");
+                    event.initKeyEvent(type, options.bubbles, options.cancelable, options.view,
+                        options.ctrlKey, options.altKey, options.shiftKey, options.metaKey,
+                        options.keyCode, options.charCode);
+                    // initKeyEvent throws an exception in WebKit
+                    // see: http://stackoverflow.com/questions/6406784/initkeyevent-keypress-only-works-in-firefox-need-a-cross-browser-solution
+                    // and also https://bugs.webkit.org/show_bug.cgi?id=13368
+                    // fall back to a generic event until we decide to implement initKeyboardEvent
+                } catch (err) {
+                    event = document.createEvent("Events");
+                    event.initEvent(type, options.bubbles, options.cancelable);
+                    $.extend(event, {
+                        view: options.view,
+                        ctrlKey: options.ctrlKey,
+                        altKey: options.altKey,
+                        shiftKey: options.shiftKey,
+                        metaKey: options.metaKey,
+                        keyCode: options.keyCode,
+                        charCode: options.charCode
+                    });
+                }
+            } else if (document.createEventObject) {
+                event = document.createEventObject();
+                $.extend(event, options);
+            }
 
-		if ( !!/msie [\w.]+/.exec( navigator.userAgent.toLowerCase() ) || (({}).toString.call( window.opera ) === "[object Opera]") ) {
-			event.keyCode = (options.charCode > 0) ? options.charCode : options.keyCode;
-			event.charCode = undefined;
-		}
+            if (!!/msie [\w.]+/.exec(navigator.userAgent.toLowerCase()) || (({}).toString.call(window.opera) === "[object Opera]")) {
+                event.keyCode = (options.charCode > 0) ? options.charCode : options.keyCode;
+                event.charCode = undefined;
+            }
 
-		return event;
-	},
+            return event;
+        },
 
-	dispatchEvent: function( elem, type, event ) {
-		if ( elem[ type ] ) {
-			elem[ type ]();
-		} else if ( elem.dispatchEvent ) {
-			elem.dispatchEvent( event );
-		} else if ( elem.fireEvent ) {
-			elem.fireEvent( "on" + type, event );
-		}
-	},
+        dispatchEvent: function (elem, type, event) {
+            if (elem[type]) {
+                elem[type]();
+            } else if (elem.dispatchEvent) {
+                elem.dispatchEvent(event);
+            } else if (elem.fireEvent) {
+                elem.fireEvent("on" + type, event);
+            }
+        },
 
-	simulateFocus: function() {
-		var focusinEvent,
-			triggered = false,
-			element = $( this.target );
+        simulateFocus: function () {
+            var focusinEvent,
+                triggered = false,
+                element = $(this.target);
 
-		function trigger() {
-			triggered = true;
-		}
+            function trigger() {
+                triggered = true;
+            }
 
-		element.bind( "focus", trigger );
-		element[ 0 ].focus();
+            element.bind("focus", trigger);
+            element[0].focus();
 
-		if ( !triggered ) {
-			focusinEvent = $.Event( "focusin" );
-			focusinEvent.preventDefault();
-			element.trigger( focusinEvent );
-			element.triggerHandler( "focus" );
-		}
-		element.unbind( "focus", trigger );
-	},
+            if (!triggered) {
+                focusinEvent = $.Event("focusin");
+                focusinEvent.preventDefault();
+                element.trigger(focusinEvent);
+                element.triggerHandler("focus");
+            }
+            element.unbind("focus", trigger);
+        },
 
-	simulateBlur: function() {
-		var focusoutEvent,
-			triggered = false,
-			element = $( this.target );
+        simulateBlur: function () {
+            var focusoutEvent,
+                triggered = false,
+                element = $(this.target);
 
-		function trigger() {
-			triggered = true;
-		}
+            function trigger() {
+                triggered = true;
+            }
 
-		element.bind( "blur", trigger );
-		element[ 0 ].blur();
+            element.bind("blur", trigger);
+            element[0].blur();
 
-		// blur events are async in IE
-		setTimeout(function() {
-			// IE won't let the blur occur if the window is inactive
-			if ( element[ 0 ].ownerDocument.activeElement === element[ 0 ] ) {
-				element[ 0 ].ownerDocument.body.focus();
-			}
+            // blur events are async in IE
+            setTimeout(function () {
+                // IE won't let the blur occur if the window is inactive
+                if (element[0].ownerDocument.activeElement === element[0]) {
+                    element[0].ownerDocument.body.focus();
+                }
 
-			// Firefox won't trigger events if the window is inactive
-			// IE doesn't trigger events if we had to manually focus the body
-			if ( !triggered ) {
-				focusoutEvent = $.Event( "focusout" );
-				focusoutEvent.preventDefault();
-				element.trigger( focusoutEvent );
-				element.triggerHandler( "blur" );
-			}
-			element.unbind( "blur", trigger );
-		}, 1 );
-	}
-});
+                // Firefox won't trigger events if the window is inactive
+                // IE doesn't trigger events if we had to manually focus the body
+                if (!triggered) {
+                    focusoutEvent = $.Event("focusout");
+                    focusoutEvent.preventDefault();
+                    element.trigger(focusoutEvent);
+                    element.triggerHandler("blur");
+                }
+                element.unbind("blur", trigger);
+            }, 1);
+        }
+    });
 
 
+    /** complex events **/
 
-/** complex events **/
+    function findCenter(elem) {
+        var offset,
+            document = $(elem.ownerDocument);
+        elem = $(elem);
+        offset = elem.offset();
 
-function findCenter( elem ) {
-	var offset,
-		document = $( elem.ownerDocument );
-	elem = $( elem );
-	offset = elem.offset();
+        return {
+            x: offset.left + elem.outerWidth() / 2 - document.scrollLeft(),
+            y: offset.top + elem.outerHeight() / 2 - document.scrollTop()
+        };
+    }
 
-	return {
-		x: offset.left + elem.outerWidth() / 2 - document.scrollLeft(),
-		y: offset.top + elem.outerHeight() / 2 - document.scrollTop()
-	};
-}
+    function findCorner(elem) {
+        var offset,
+            document = $(elem.ownerDocument);
+        elem = $(elem);
+        offset = elem.offset();
 
-function findCorner( elem ) {
-	var offset,
-		document = $( elem.ownerDocument );
-	elem = $( elem );
-	offset = elem.offset();
+        return {
+            x: offset.left - document.scrollLeft(),
+            y: offset.top - document.scrollTop()
+        };
+    }
 
-	return {
-		x: offset.left - document.scrollLeft(),
-		y: offset.top - document.scrollTop()
-	};
-}
+    function hasNoMoves(moves, dx, dy) {
+        return typeof (moves) !== "number" || (moves === 0 && (dx !== 0 || dy !== 0));
+    }
 
-function hasNoMoves(moves, dx, dy) {
-	return typeof(moves) !== "number" || (moves === 0 && (dx !== 0 || dy !== 0));
-}
+    $.extend($.simulate.prototype, {
+        simulateDrag: function () {
+            var i = 0,
+                target = this.target,
+                userOptions = this.options,
+                center = userOptions.handle === "corner" ? findCorner(target) : findCenter(target),
+                x = Math.floor(center.x),
+                y = Math.floor(center.y),
+                event = {
+                    clientX: x,
+                    clientY: y,
+                    ctrlKey: userOptions.ctrlKey
+                },
+                dx = userOptions.dx || (userOptions.x !== undefined ? userOptions.x - x : 0),
+                dy = userOptions.dy || (userOptions.y !== undefined ? userOptions.y - y : 0),
+                moves = hasNoMoves(userOptions.moves, dx, dy) ? 3 : userOptions.moves;
 
-$.extend( $.simulate.prototype, {
-	simulateDrag: function() {
-		var i = 0,
-			target = this.target,
-			options = this.options,
-			center = options.handle === "corner" ? findCorner( target ) : findCenter( target ),
-			x = Math.floor( center.x ),
-			y = Math.floor( center.y ),
-			coord = { clientX: x, clientY: y },
-			dx = options.dx || ( options.x !== undefined ? options.x - x : 0 ),
-			dy = options.dy || ( options.y !== undefined ? options.y - y : 0 ),
-			moves = hasNoMoves(options.moves, dx, dy) ? 3 : options.moves;
+            this.simulateEvent(target, "mousedown", event);
 
-		this.simulateEvent( target, "mousedown", coord );
+            for (; i < moves; i++) {
+                x += dx / moves;
+                y += dy / moves;
 
-		for ( ; i < moves ; i++ ) {
-			x += dx / moves;
-			y += dy / moves;
+                event.clientX = Math.round(x);
+                event.clientY = Math.round(y);
 
-			coord = {
-				clientX: Math.round( x ),
-				clientY: Math.round( y )
-			};
+                this.simulateEvent(target.ownerDocument, "mousemove", event);
+            }
 
-			this.simulateEvent( target.ownerDocument, "mousemove", coord );
-		}
+            if ($.contains(document, target)) {
+                this.simulateEvent(target, "mouseup", event);
+                this.simulateEvent(target, "click", event);
+            } else {
+                this.simulateEvent(document, "mouseup", event);
+            }
+        }
+    });
 
-		if ( $.contains( document, target ) ) {
-			this.simulateEvent( target, "mouseup", coord );
-			this.simulateEvent( target, "click", coord );
-		} else {
-			this.simulateEvent( document, "mouseup", coord );
-		}
-	}
-});
-
-})( jQuery );
+})(jQuery);

--- a/jquery.simulate.js
+++ b/jquery.simulate.js
@@ -110,30 +110,6 @@ $.extend( $.simulate.prototype, {
 				options.screenX, options.screenY, options.clientX, options.clientY,
 				options.ctrlKey, options.altKey, options.shiftKey, options.metaKey,
 				options.button, options.relatedTarget || document.body.parentNode );
-
-			// IE 9+ creates events with pageX and pageY set to 0.
-			// Trying to modify the properties throws an error,
-			// so we define getters to return the correct values.
-			if ( event.pageX === 0 && event.pageY === 0 && Object.defineProperty ) {
-				eventDoc = event.relatedTarget.ownerDocument || document;
-				doc = eventDoc.documentElement;
-				body = eventDoc.body;
-
-				Object.defineProperty( event, "pageX", {
-					get: function() {
-						return options.clientX +
-							( doc && doc.scrollLeft || body && body.scrollLeft || 0 ) -
-							( doc && doc.clientLeft || body && body.clientLeft || 0 );
-					}
-				});
-				Object.defineProperty( event, "pageY", {
-					get: function() {
-						return options.clientY +
-							( doc && doc.scrollTop || body && body.scrollTop || 0 ) -
-							( doc && doc.clientTop || body && body.clientTop || 0 );
-					}
-				});
-			}
 		} else if ( document.createEventObject ) {
 			event = document.createEventObject();
 			$.extend( event, options );

--- a/test/unit/simulate.js
+++ b/test/unit/simulate.js
@@ -1,118 +1,127 @@
-(function() {
+(function () {
 
-module( "mouse events" );
+    module("mouse events");
 
-test( "click on checkbox triggers change", function() {
-	var input = $( "#radiocheckbox-3" ),
-		checked = input.prop( "checked" );
+    test("click on checkbox triggers change", function () {
+        var input = $("#radiocheckbox-3"),
+            checked = input.prop("checked");
 
-	input.simulate( "click" );
+        input.simulate("click");
 
-	notEqual( checked, input.prop( "checked" ), "checkbox state changed" );
-});
+        notEqual(checked, input.prop("checked"), "checkbox state changed");
+    });
 
-test( "click on radio triggers change", function() {
-	var firstRadio = $( "#radiocheckbox-1" ),
-		secondRadio = $( "#radiocheckbox-2" ),
-		checked = firstRadio.prop( "checked" );
+    test("click on radio triggers change", function () {
+        var firstRadio = $("#radiocheckbox-1"),
+            secondRadio = $("#radiocheckbox-2"),
+            checked = firstRadio.prop("checked");
 
-	if ( checked ) {
-		secondRadio.simulate( "click" );
-	} else {
-		firstRadio.simulate( "click" );
-	}
+        if (checked) {
+            secondRadio.simulate("click");
+        } else {
+            firstRadio.simulate("click");
+        }
 
-	notEqual( checked, firstRadio.prop( "checked" ), "radio state changed" );
-});
+        notEqual(checked, firstRadio.prop("checked"), "radio state changed");
+    });
 
-var key = jQuery.simulate.keyCode,
-	keyEvents = [ "keydown", "keyup", "keypress" ],
-	i = 0;
+    var key = jQuery.simulate.keyCode,
+        keyEvents = ["keydown", "keyup", "keypress"],
+        i = 0;
 
-module( "key events" );
+    module("key events");
 
-function testKeyEvent ( keyEvent ) {
-	test( keyEvent, function() {
-		expect( 2 );
-		jQuery("<div></div>").bind( keyEvent, function( event ) {
-			ok( true, keyEvent + " event fired" );
-			equal( event.keyCode, key.PAGE_UP, keyEvent + " event has correct keyCode" );
-		}).appendTo("#qunit-fixture").simulate( keyEvent, {
-			keyCode: key.PAGE_UP
-		});
-	});
-}
+    function testKeyEvent(keyEvent) {
+        test(keyEvent, function () {
+            expect(2);
+            jQuery("<div></div>").bind(keyEvent, function (event) {
+                ok(true, keyEvent + " event fired");
+                equal(event.keyCode, key.PAGE_UP, keyEvent + " event has correct keyCode");
+            }).appendTo("#qunit-fixture").simulate(keyEvent, {
+                keyCode: key.PAGE_UP
+            });
+        });
+    }
 
-for ( ; i < keyEvents.length; i++ ) {
-	testKeyEvent( keyEvents[ i ] );
-}
+    for (; i < keyEvents.length; i++) {
+        testKeyEvent(keyEvents[i]);
+    }
 
-module( "complex events" );
+    module("complex events");
 
-asyncTest( "drag moves option", function() {
-	var expectedMoves = 17,
-		expectedUps = 6,
-		expectedDowns = 6,
-		callsMoves = 0,
-		callsUp = 0,
-		el = jQuery("<div class='top-left'></div>").appendTo("#qunit-fixture"),
-		position;
+    asyncTest("drag moves option", function () {
+        var expectedMoves = 17,
+            expectedUps = 7,
+            expectedDowns = 7,
+            callsMoves = 0,
+            callsUp = 0,
+            el = jQuery("<div class='top-left'></div>").appendTo("#qunit-fixture"),
+            position;
 
-	expect(expectedUps + expectedDowns + expectedMoves);
+        expect(expectedUps + expectedDowns + expectedMoves);
 
-	jQuery(document).bind("mousedown", function (event) {
-		ok(true, "mousedown event fired at the document");
-		position = {
-			clientX: event.clientX,
-			clientY: event.clientY
-		};
-	}).bind("mouseup", function () {
-		ok(true, "mouseup event fired at the document");
-		if (++callsUp === expectedUps) {
-			jQuery(document)
-				.unbind("mousedown")
-				.unbind("mousemove")
-				.unbind("mouseup");
-			start();
-		}
-	}).bind("mousemove", function (event) {
-		ok(true, "mousemove event fired at the document");
-		if (++callsMoves === expectedMoves - 2) {
-			equal(position.clientX + 10, event.clientX, "last mousemove fired at correct clientX");
-			equal(position.clientY + 20, event.clientY, "last mousemove fired at correct clientX");
-		}
-	});
+        jQuery(document).bind("mousedown", function (event) {
+            ok(true, "mousedown event fired at the document");
+            position = {
+                clientX: event.clientX,
+                clientY: event.clientY
+            };
+        }).bind("mouseup", function () {
+            ok(true, "mouseup event fired at the document");
+            if (++callsUp === expectedUps) {
+                jQuery(document)
+                    .unbind("mousedown")
+                    .unbind("mousemove")
+                    .unbind("mouseup");
+                start();
 
-	el.simulate( "drag", {
-		moves: 1,
-		dx: 10,
-		dy: 20
-	}).simulate( "drag", {
-		moves: 5,
-		dx: 10,
-		dy: 20
-	});
+            }
+        }).bind("mousemove", function (event) {
+            if (event.ctrlKey === false) {
+                ok(true, "mousemove event fired at the document");
+                if (++callsMoves === expectedMoves - 2) {
+                    equal(position.clientX + 10, event.clientX, "last mousemove fired at correct clientX");
+                    equal(position.clientY + 20, event.clientY, "last mousemove fired at correct clientX");
+                }
+            }
+        });
 
-	// falsey defaults to 3
-	el.simulate( "drag", {
-		moves: 0,
-		dx: 10,
-		dy: 20
-	}).simulate( "drag", {
-		dx: 10,
-		dy: 20
-	}).simulate( "drag", {
-		moves: null,
-		dx: 10,
-		dy: 20
-	});
-	
-	// no moves
-	el.simulate("drag", {
-		moves: 0,
-		dx: 0,
-		dy: 0
-	});
-});
+        el.simulate("drag", {
+            moves: 1,
+            dx: 0,
+            dy: 0,
+            ctrlKey: true
+        })
+        el.simulate("drag", {
+            moves: 1,
+            dx: 10,
+            dy: 20
+        }).simulate("drag", {
+            moves: 5,
+            dx: 10,
+            dy: 20
+        });
+
+        // falsey defaults to 3
+        el.simulate("drag", {
+            moves: 0,
+            dx: 10,
+            dy: 20
+        }).simulate("drag", {
+            dx: 10,
+            dy: 20
+        }).simulate("drag", {
+            moves: null,
+            dx: 10,
+            dy: 20
+        });
+
+        // no moves
+        el.simulate("drag", {
+            moves: 0,
+            dx: 0,
+            dy: 0
+        });
+    });
 
 })();

--- a/test/unit/simulate.js
+++ b/test/unit/simulate.js
@@ -50,26 +50,36 @@ for ( ; i < keyEvents.length; i++ ) {
 module( "complex events" );
 
 asyncTest( "drag moves option", function() {
-
-	var moves = 15,
-		calls = 0,
+	var expectedMoves = 17,
+		expectedUps = 6,
+		expectedDowns = 6,
+		callsMoves = 0,
+		callsUp = 0,
 		el = jQuery("<div class='top-left'></div>").appendTo("#qunit-fixture"),
 		position;
 
-	expect( moves + 2 );
+	expect(expectedUps + expectedDowns + expectedMoves);
 
-	jQuery( document ).bind( "mousedown", function( event ) {
+	jQuery(document).bind("mousedown", function (event) {
+		ok(true, "mousedown event fired at the document");
 		position = {
-			clientX : event.clientX,
-			clientY : event.clientY
+			clientX: event.clientX,
+			clientY: event.clientY
 		};
-	}).bind( "mousemove", function( event ) {
-		ok( true, "mousemove event fired at the document" );
-		if ( ++calls === moves ) {
-			equal( position.clientX + 10, event.clientX, "last mousemove fired at correct clientX" );
-			equal( position.clientY + 20, event.clientY, "last mousemove fired at correct clientX" );
-			jQuery( document ).unbind("mousemove").unbind("mousedown");
+	}).bind("mouseup", function () {
+		ok(true, "mouseup event fired at the document");
+		if (++callsUp === expectedUps) {
+			jQuery(document)
+				.unbind("mousedown")
+				.unbind("mousemove")
+				.unbind("mouseup");
 			start();
+		}
+	}).bind("mousemove", function (event) {
+		ok(true, "mousemove event fired at the document");
+		if (++callsMoves === expectedMoves - 2) {
+			equal(position.clientX + 10, event.clientX, "last mousemove fired at correct clientX");
+			equal(position.clientY + 20, event.clientY, "last mousemove fired at correct clientX");
 		}
 	});
 
@@ -95,6 +105,13 @@ asyncTest( "drag moves option", function() {
 		moves: null,
 		dx: 10,
 		dy: 20
+	});
+	
+	// no moves
+	el.simulate("drag", {
+		moves: 0,
+		dx: 0,
+		dy: 0
 	});
 });
 


### PR DESCRIPTION
I've added this case for the simulation of the drag event:
`element.simulate("drag", { moves: 0, dx: 0, dy: 0 });`
Using Snap SVG I need to simulate in tests a drag without moves. It will be fired only _mouseup_ and _mousedown_.
Only when _dx_ and _dy_ equal zero I will not assign the default of _3_ moves. I have also increased the test of the _drag_ including expectations for the _mouseup_ and _mousedown_.
