### PR TITLE
Enable options by using e.dispatchEvent

### DIFF
--- a/jquery.simulate.js
+++ b/jquery.simulate.js
@@ -201,10 +201,10 @@ $.extend( $.simulate.prototype, {
 	},
 
 	dispatchEvent: function( elem, type, event ) {
-		if ( elem[ type ] ) {
-			elem[ type ]();
-		} else if ( elem.dispatchEvent ) {
+		if ( elem.dispatchEvent ) {
 			elem.dispatchEvent( event );
+		} else if ( type === "click" && elem.click && elem.nodeName.toLowerCase() === "input" ) {
+			elem.click();
 		} else if ( elem.fireEvent ) {
 			elem.fireEvent( "on" + type, event );
 		}

--- a/test/unit/simulate.js
+++ b/test/unit/simulate.js
@@ -1,6 +1,13 @@
 (function() {
+var IE8Check = window.attachEvent && !window.addEventListener,
+	key = jQuery.simulate.keyCode,
+	clickOptions,
+	keyEvents,
+	keyOptions;
 
 module( "mouse events" );
+
+clickOptions = [ "ctrlKey", "altKey", "shiftKey", "metaKey" ];
 
 test( "click on checkbox triggers change", function() {
 	var input = $( "#radiocheckbox-3" ),
@@ -25,27 +32,106 @@ test( "click on radio triggers change", function() {
 	notEqual( checked, firstRadio.prop( "checked" ), "radio state changed" );
 });
 
-var key = jQuery.simulate.keyCode,
-	keyEvents = [ "keydown", "keyup", "keypress" ],
-	i = 0;
+test( "click", function() {
+	expect( 6 );
+	jQuery( "<div></div>" ).bind( "click", function( event ) {
+		var value = IE8Check ? 1 : 0;
+
+		ok( true, "click event fired" );
+		equal( event.button, value, "click event was fired with left mouse button" );
+		equal( event.ctrlKey, false, "click event was fired without control key" );
+		equal( event.metaKey, false, "click event was fired without meta key" );
+		equal( event.shiftKey, false, "click event was fired without shift key" );
+		equal( event.altKey, false, "click event was fired without alt key" );
+	}).appendTo( "#qunit-fixture" ).simulate( "click" );
+});
+
+test( "click with middle mouse button", function() {
+	expect( 2 );
+	jQuery( "<div></div>" ).bind( "click", function( event ) {
+		var value = IE8Check ? 4 : 1;
+
+		ok( true, "click event fired" );
+		equal( event.button, value, "click event was fired with middle mouse button" );
+	}).appendTo( "#qunit-fixture" ).simulate( "click", {
+		button: 1
+	});
+});
+
+test( "click with right mouse button", function() {
+	expect( 2 );
+	jQuery( "<div></div>" ).bind( "click", function( event ) {
+		ok( true, "click event fired" );
+		equal( event.button, 2, "click event was fired with right mouse button" );
+	}).appendTo( "#qunit-fixture" ).simulate( "click", {
+		button: 2
+	});
+});
+
+function testClickEvent( clickOption ) {
+	var options = {};
+	options[ clickOption ] = true;
+
+	test( "click with " + clickOption, function() {
+		expect( 2 );
+		jQuery( "<div></div>" ).bind( "click", function( event ) {
+			ok( true, "click event fired" );
+			equal( event[ clickOption ], true, "click event was fired with " + clickOption );
+		}).appendTo( "#qunit-fixture" ).simulate( "click", options);
+	});
+}
+
+jQuery.each(clickOptions, function( index, clickOption ) {
+	testClickEvent( clickOption );
+});
 
 module( "key events" );
 
+keyEvents = [ "keydown", "keyup", "keypress" ];
+keyOptions = [ "ctrlKey", "altKey", "shiftKey", "metaKey" ];
+
 function testKeyEvent ( keyEvent ) {
 	test( keyEvent, function() {
-		expect( 2 );
+		expect( 2 + keyOptions.length );
 		jQuery("<div></div>").bind( keyEvent, function( event ) {
+			var i = 0;
+
 			ok( true, keyEvent + " event fired" );
 			equal( event.keyCode, key.PAGE_UP, keyEvent + " event has correct keyCode" );
+
+			for ( i; i < keyOptions.length; i++ ) {
+				equal( event[ keyOptions[ i ] ], false, keyEvent + " event fired without " + keyOptions[ i ] );
+			}
 		}).appendTo("#qunit-fixture").simulate( keyEvent, {
 			keyCode: key.PAGE_UP
 		});
 	});
 }
 
-for ( ; i < keyEvents.length; i++ ) {
-	testKeyEvent( keyEvents[ i ] );
+function testKeyEventOption ( keyEvent, keyOption ) {
+	test( keyEvent + " with " + keyOption, function() {
+		var options = {
+			keyCode: key.PAGE_UP
+		};
+		options[ keyOption ] = true;
+
+		expect( 3 );
+		jQuery("<div></div>").bind( keyEvent, function( event ) {
+			ok( true, keyEvent + " event fired" );
+			equal( event.keyCode, key.PAGE_UP, keyEvent + " event has correct keyCode" );
+			equal( event[keyOption], true, keyEvent + " event fired with " + keyOption );
+		}).appendTo("#qunit-fixture").simulate( keyEvent, options);
+	});
 }
+
+jQuery.each(keyEvents, function( index, keyEvent ) {
+	testKeyEvent( keyEvent );
+
+	jQuery.each(keyOptions, function( index, keyOption ) {
+		testKeyEventOption( keyEvent, keyOption );
+	});
+});
+
 
 module( "complex events" );
 


### PR DESCRIPTION
The current implementation allows developers to include an optional `options` parameter but doesn't actually use it. As such, this change should not affect any pre-existing use cases, but opens up the option for those who might want to have more granular control over the event they are simulating.